### PR TITLE
fix: schema中存在example值，但无法mock

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,7 @@ function primitive (schema) {
   var format = schema.format
   var value = primitives[type + '_' + format] || primitives[type]
 
-  return value || 'Unknown Type: ' + schema.type
+  return schema.example || value || 'Unknown Type: ' + schema.type
 }
 
 function sampleFromSchema (schema) {


### PR DESCRIPTION
解决在swagger中的respone Object的schema中存在example，但是mock的时候还是用的随机数据，修改之后如果存在example，则mock的时候使用example的值，如果example不存在，则使用随机数据